### PR TITLE
Rename ToolsDB data source

### DIFF
--- a/ansible/templates/values.yaml.j2
+++ b/ansible/templates/values.yaml.j2
@@ -114,7 +114,7 @@ extraConfigs:
       password: {{ replicaPass }}
       sqlalchemy_uri: mysql+mysqldb://s52788@s8.analytics.db.svc.wikimedia.cloud:3306/information_schema?ssl=1
       allow_run_async: true
-    - database_name: s55986__automod_metrics_p
+    - database_name: ToolsDB
       password: {{ toolsdbPass }}
       sqlalchemy_uri: mysql+mysqldb://superset_readonly@tools-readonly.db.svc.wikimedia.cloud:3306/information_schema?ssl=1
       allow_run_async: true


### PR DESCRIPTION
The current database name is wrong, the real database name is specified in the connection URL and is "information_schema".

As discussed in the Phab task, it makes sense to call this data source simply "ToolsDB" and let users select their desired database in their SQL queries.

Bug: [T367393](https://phabricator.wikimedia.org/T367393)